### PR TITLE
ENH: use numpyro implementation of dismod at to derive a consistent remission rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ dmypy.json
 
 # Version file
 src/*/_version.py
+*~

--- a/artifact_requirements.txt
+++ b/artifact_requirements.txt
@@ -17,3 +17,7 @@ black==22.3.0
 isort
 jupyterlab
 matplotlib
+jax
+numpyro
+diffrax
+interpax

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     setup_requires = ["setuptools_scm"]
 
-    data_requirements = ["vivarium_inputs[data]>=5.0.7"]
+    data_requirements = ["vivarium_inputs[data]>=5.0.7", "jax", "numpyro", "diffrax", "interpax"]
     cluster_requirements = ["vivarium_cluster_tools>=2.0.3"]
     test_requirements = ["pytest"]
     lint_requirements = ["black", "isort"]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,13 @@ if __name__ == "__main__":
 
     setup_requires = ["setuptools_scm"]
 
-    data_requirements = ["vivarium_inputs[data]>=5.0.7", "jax", "numpyro", "diffrax", "interpax"]
+    data_requirements = [
+        "vivarium_inputs[data]>=5.0.7",
+        "jax",
+        "numpyro",
+        "diffrax",
+        "interpax",
+    ]
     cluster_requirements = ["vivarium_cluster_tools>=2.0.3"]
     test_requirements = ["pytest"]
     lint_requirements = ["black", "isort"]

--- a/src/vivarium_nih_moud/data/builder.py
+++ b/src/vivarium_nih_moud/data/builder.py
@@ -153,7 +153,6 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
     ]:
         data = art.load(key)
         write_or_replace(art, key.replace("opioid_use_disorders", "oud_consistent"), data)
-    assert 0
 
     ages = np.arange(0, 96, 5)
     years = np.array([2020, 2025])

--- a/src/vivarium_nih_moud/data/builder.py
+++ b/src/vivarium_nih_moud/data/builder.py
@@ -147,12 +147,14 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
     # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
 
     # copy metadata
-    for key in ['cause.opioid_use_disorders.restrictions',
-                'cause.opioid_use_disorders.disability_weight']:
+    for key in [
+        "cause.opioid_use_disorders.restrictions",
+        "cause.opioid_use_disorders.disability_weight",
+    ]:
         data = art.load(key)
-        write_or_replace(art, key.replace('opioid_use_disorders', 'oud_consistent'), data)
+        write_or_replace(art, key.replace("opioid_use_disorders", "oud_consistent"), data)
     assert 0
-    
+
     ages = np.arange(0, 96, 5)
     years = np.array([2020, 2025])
     sexes = ["Male", "Female"]
@@ -204,16 +206,17 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
             rate_name = key[rate_type]
         else:
             rate_name = "cause.opioid_use_disorders.remission_rate"
-        rate_name = rate_name.replace('opioid_use_disorders', 'oud_consistent')
+        rate_name = rate_name.replace("opioid_use_disorders", "oud_consistent")
         write_or_replace(art, rate_name, df_out)
 
     # then do cause specific mortality rate
-    df_out = get_rates(m, 'p', 2020) * get_rates(m, 'f', 2020)
-    rate_name = 'cause.oud_consistent.cause_specific_mortality_rate'
+    df_out = get_rates(m, "p", 2020) * get_rates(m, "f", 2020)
+    rate_name = "cause.oud_consistent.cause_specific_mortality_rate"
     write_or_replace(art, rate_name, df_out)
 
+
 def write_or_replace(art, key, data):
-        if key in art.keys:
-            art.replace(key, data)
-        else:
-            art.write(key, data)
+    if key in art.keys:
+        art.replace(key, data)
+    else:
+        art.write(key, data)

--- a/src/vivarium_nih_moud/data/builder.py
+++ b/src/vivarium_nih_moud/data/builder.py
@@ -146,6 +146,13 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
     """
     # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
 
+    # copy metadata
+    for key in ['cause.opioid_use_disorders.restrictions',
+                'cause.opioid_use_disorders.disability_weight']:
+        data = art.load(key)
+        write_or_replace(art, key.replace('opioid_use_disorders', 'oud_consistent'), data)
+    assert 0
+    
     ages = np.arange(0, 96, 5)
     years = np.array([2020, 2025])
     sexes = ["Male", "Female"]
@@ -197,8 +204,16 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
             rate_name = key[rate_type]
         else:
             rate_name = "cause.opioid_use_disorders.remission_rate"
-        rate_name += "_consistent"
-        if rate_name in art.keys:
-            art.replace(rate_name, df_out)
+        rate_name = rate_name.replace('opioid_use_disorders', 'oud_consistent')
+        write_or_replace(art, rate_name, df_out)
+
+    # then do cause specific mortality rate
+    df_out = get_rates(m, 'p', 2020) * get_rates(m, 'f', 2020)
+    rate_name = 'cause.oud_consistent.cause_specific_mortality_rate'
+    write_or_replace(art, rate_name, df_out)
+
+def write_or_replace(art, key, data):
+        if key in art.keys:
+            art.replace(key, data)
         else:
-            art.write(rate_name, df_out)
+            art.write(key, data)

--- a/src/vivarium_nih_moud/data/builder.py
+++ b/src/vivarium_nih_moud/data/builder.py
@@ -12,13 +12,12 @@ Some degree of verbosity/boilerplate is fine in the interest of transparency.
 from pathlib import Path
 from typing import Optional
 
-import pandas as pd
+import numpy as np, pandas as pd
 from loguru import logger
 from vivarium.framework.artifact import Artifact, EntityKey
 
-from vivarium_nih_moud.constants import data_keys
-from vivarium_nih_moud.data import loader
-
+from ..constants import data_keys
+from ..data import loader, dismod_at
 
 def open_artifact(output_path: Path, location: str) -> Artifact:
     """Creates or opens an artifact at the output path.
@@ -127,3 +126,72 @@ def write_data_by_draw(artifact: Artifact, key: str, data: pd.DataFrame):
         data = data.reset_index(drop=True)
         for c in data.columns:
             store.put(f"{key.path}/{c}", data[c])
+
+def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional[str]):
+    """Generates consistent rates for MOUD data.
+
+    Parameters
+    ----------
+    art
+        The artifact to read from and write to.
+    location
+        The location associated with the data to load and the artifact to
+        write to.
+    years
+        The years to load data for.
+
+    """
+    # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
+
+    ages = np.arange(0, 96, 5)
+    years = np.array([
+        2020, 2025
+    ])
+    sexes = ['Male', 
+            'Female'
+            ]
+    key = {
+        'i': 'cause.opioid_use_disorders.incidence_rate',
+        'p': 'cause.opioid_use_disorders.prevalence',
+        'f': 'cause.opioid_use_disorders.excess_mortality_rate',
+        'm_all': 'cause.all_causes.cause_specific_mortality_rate',
+        'csmr_with': 'cause.opioid_use_disorders.cause_specific_mortality_rate',
+        'pop': 'population.structure'
+    }
+
+    def oud_data(sex):
+        df_data = pd.concat([
+            dismod_at.transform_to_data('p', art.load(key['p']), sex, ages, [2021]),
+            dismod_at.transform_to_data('i', art.load(key['i']), sex, ages, [2021]),
+            dismod_at.transform_to_data('f', art.load(key['f']), sex, ages, [2021]),
+            dismod_at.transform_to_data('m', art.load(key['m_all']) - art.load(key['csmr_with']), sex, ages, [2021]),
+        ])
+        return df_data
+    
+    def get_rates(model_dict, rate_type, year):
+        df_out = []
+        for model in model_dict.values():
+            df_out.append(model.get_rate(rate_type, year))
+        df_out = pd.concat(df_out)
+        return df_out
+
+    # fit model separately for Male and Female
+    m = {}
+    for sex in sexes:
+        m[sex] = dismod_at.ConsistentModel(sex, ages, years)
+        m[sex].fit(oud_data(sex))
+
+    # store consistent rates in artifact        
+    for rate_type in 'ipfr':
+        # generate data for k
+        df_out = get_rates(m, rate_type, 2020)
+        # store generated data in artifact
+        if rate_type != 'r':
+            rate_name = key[rate_type]
+        else:
+            rate_name = 'cause.opioid_use_disorders.remission_rate'
+        rate_name += '_consistent'
+        if rate_name in art.keys:
+            art.replace(rate_name, df_out)
+        else:
+            art.write(rate_name, df_out)

--- a/src/vivarium_nih_moud/data/builder.py
+++ b/src/vivarium_nih_moud/data/builder.py
@@ -12,12 +12,14 @@ Some degree of verbosity/boilerplate is fine in the interest of transparency.
 from pathlib import Path
 from typing import Optional
 
-import numpy as np, pandas as pd
+import numpy as np
+import pandas as pd
 from loguru import logger
 from vivarium.framework.artifact import Artifact, EntityKey
 
 from ..constants import data_keys
-from ..data import loader, dismod_at
+from ..data import dismod_at, loader
+
 
 def open_artifact(output_path: Path, location: str) -> Artifact:
     """Creates or opens an artifact at the output path.
@@ -127,6 +129,7 @@ def write_data_by_draw(artifact: Artifact, key: str, data: pd.DataFrame):
         for c in data.columns:
             store.put(f"{key.path}/{c}", data[c])
 
+
 def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional[str]):
     """Generates consistent rates for MOUD data.
 
@@ -144,30 +147,34 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
     # TODO: check if the consistent rates are already in the artifact, and if so, skip rest of this function
 
     ages = np.arange(0, 96, 5)
-    years = np.array([
-        2020, 2025
-    ])
-    sexes = ['Male', 
-            'Female'
-            ]
+    years = np.array([2020, 2025])
+    sexes = ["Male", "Female"]
     key = {
-        'i': 'cause.opioid_use_disorders.incidence_rate',
-        'p': 'cause.opioid_use_disorders.prevalence',
-        'f': 'cause.opioid_use_disorders.excess_mortality_rate',
-        'm_all': 'cause.all_causes.cause_specific_mortality_rate',
-        'csmr_with': 'cause.opioid_use_disorders.cause_specific_mortality_rate',
-        'pop': 'population.structure'
+        "i": "cause.opioid_use_disorders.incidence_rate",
+        "p": "cause.opioid_use_disorders.prevalence",
+        "f": "cause.opioid_use_disorders.excess_mortality_rate",
+        "m_all": "cause.all_causes.cause_specific_mortality_rate",
+        "csmr_with": "cause.opioid_use_disorders.cause_specific_mortality_rate",
+        "pop": "population.structure",
     }
 
     def oud_data(sex):
-        df_data = pd.concat([
-            dismod_at.transform_to_data('p', art.load(key['p']), sex, ages, [2021]),
-            dismod_at.transform_to_data('i', art.load(key['i']), sex, ages, [2021]),
-            dismod_at.transform_to_data('f', art.load(key['f']), sex, ages, [2021]),
-            dismod_at.transform_to_data('m', art.load(key['m_all']) - art.load(key['csmr_with']), sex, ages, [2021]),
-        ])
+        df_data = pd.concat(
+            [
+                dismod_at.transform_to_data("p", art.load(key["p"]), sex, ages, [2021]),
+                dismod_at.transform_to_data("i", art.load(key["i"]), sex, ages, [2021]),
+                dismod_at.transform_to_data("f", art.load(key["f"]), sex, ages, [2021]),
+                dismod_at.transform_to_data(
+                    "m",
+                    art.load(key["m_all"]) - art.load(key["csmr_with"]),
+                    sex,
+                    ages,
+                    [2021],
+                ),
+            ]
+        )
         return df_data
-    
+
     def get_rates(model_dict, rate_type, year):
         df_out = []
         for model in model_dict.values():
@@ -181,16 +188,16 @@ def generate_consistent_moud_rates(art: Artifact, location: str, years: Optional
         m[sex] = dismod_at.ConsistentModel(sex, ages, years)
         m[sex].fit(oud_data(sex))
 
-    # store consistent rates in artifact        
-    for rate_type in 'ipfr':
+    # store consistent rates in artifact
+    for rate_type in "ipfr":
         # generate data for k
         df_out = get_rates(m, rate_type, 2020)
         # store generated data in artifact
-        if rate_type != 'r':
+        if rate_type != "r":
             rate_name = key[rate_type]
         else:
-            rate_name = 'cause.opioid_use_disorders.remission_rate'
-        rate_name += '_consistent'
+            rate_name = "cause.opioid_use_disorders.remission_rate"
+        rate_name += "_consistent"
         if rate_name in art.keys:
             art.replace(rate_name, df_out)
         else:

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -1,0 +1,255 @@
+"""NumPyro/JAX implementation of DisMod-AT, refactored from notebook 2024_07_28a_dismod_ipd_ai_refactor.ipynb
+"""
+import numpy as np, pandas as pd
+
+import jax
+import jax.numpy as jnp
+
+import numpyro
+from numpyro import distributions as dist, infer
+
+from diffrax import diffeqsolve, Dopri5, ODETerm, SaveAt
+import interpax
+
+from typing import Callable
+
+
+def transform_to_data(param, df_in, sex, ages, years, location):
+    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
+    t = df_in.loc[(location, sex)]
+    results = []  # fill with rows of data, then convert to a dataframe
+    
+    for a in ages:
+        for y in years:
+            row = {'age_start': a, 'age_end': a, 'year_start': y, 'year_end':y, 'sex':sex,
+                   'measure': param, 
+                  }
+            tt = t.query('age_start <= @a and @a < age_end and year_start <= @y and @y < year_end')
+            assert len(tt) == 1
+            row['mean'] = np.mean(tt.iloc[0])
+            row['standard_error'] = (np.std(tt.iloc[0])
+                                     + .00000001 # add a little bit to the s2 for everything, just to avoid zeros
+                                    )
+
+            
+            results.append(row)
+
+    return pd.DataFrame(results)
+
+def transform_to_prior(df, sex, ages, years, location):
+    """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
+    t = df.loc[(location, sex)]
+    mu = pd.DataFrame(index=ages, columns=years, dtype=float)
+    s2 = pd.DataFrame(index=ages, columns=years, dtype=float)
+    
+    for a in ages:
+        for y in years:
+            tt = t.query('age_start <= @a and @a < age_end and year_start <= @y and @y < year_end')
+            assert len(tt) == 1
+            mu.loc[a,y] = np.mean(tt.iloc[0])
+            s2.loc[a,y] = np.var(tt.iloc[0])
+    
+    return mu, s2
+
+def at_param(name: str, ages, years, knot_val, method='constant') -> Callable:
+    """Create an age- and time-specific rate function for a DisMod model.
+
+    This function generates a 2d-interpolated rate function
+    with a TruncatedNormal prior.
+
+    It uses `searchsorted` as an efficient piecewise constant
+    interpolation method.
+
+    Parameters
+    ----------
+    name : str
+        The name of the rate parameter.
+    ages : array-like
+    years : array-like
+    knot_val : array-like with rows for ages and columns for years
+    method : str, interpolation method of "constant" or "linear"
+
+    Returns
+    -------
+    function
+        A function `f(a, t)` that takes array-like values age `a`
+        and time `t` as inputs and returns the interpolated rate value
+        specific to the given age and time. 
+
+    Notes
+    -----
+    - For constant interpolation, the `searchsorted` method is set to
+      'scan', which is allegedly efficient for GPU computation.
+
+    """
+
+    if method=='constant':
+        def f(a: jnp.ndarray, t: jnp.ndarray) -> jnp.ndarray:
+            method = 'scan'  # 'scan_unrolled' can be more performant on GPU at the
+                             # expense of additional compile time
+            a_index = jnp.searchsorted(jnp.asarray(ages[1:]),  # Start from ages[1] 
+                                       # so that ages less than ages[1] map to 
+                                       # index 0
+                                       jnp.asarray(a), method=method, side='right')
+            t_index = jnp.searchsorted(jnp.asarray(years[1:]),  # Start from years[1] 
+                                       # so that years less than years[1] map to 
+                                       # index 0
+                                       jnp.asarray(t), method=method, side='right')
+            return knot_val[a_index, t_index]
+    elif method == 'linear':
+        f = interpax.Interpolator2D(ages, years, knot_val, method='linear', extrap=True)
+    else:
+        assert 0, f'Method "{method}" unrecognized, should be "constant" or "linear"'
+    return f
+
+def data_model(name, f, df_data): # FIXME: expose beta so it can be common across locations
+    if len(df_data) == 0:
+        return
+    
+    ages = jnp.array(.5 * (df_data.age_start + df_data.age_end))
+    years = jnp.array(.5 * (df_data.year_start + df_data.year_end))
+    rate_obs_loc = jnp.array(df_data['mean'])
+    rate_obs_scale = jnp.array(df_data['standard_error'])
+
+    # refactor the following to use jax.vmap and to include population weights
+    rate_pred = jnp.zeros(len(df_data))
+    n_points = 5
+    for alpha in np.linspace(0,1,n_points): 
+        ages = jnp.array(alpha*df_data.age_start + (1-alpha)*df_data.age_end)
+        rate_pred += f(ages, years)
+    rate_pred /= n_points
+    
+    if len(df_data.filter(like='x_').columns) != 0:
+        # include fixed effects
+        X = jnp.array(df_data.filter(like='x_').fillna(0))
+        beta = numpyro.sample(
+            f'{name}_beta',
+            dist.Normal(loc=jnp.zeros(len(X[0])),
+                        scale=1.0
+                   ),
+        )
+        rate_pred = jnp.exp(jnp.dot(X, beta)) * rate_pred
+    
+    rate_obs = numpyro.sample(
+        f'{name}_obs',
+        dist.Normal(loc=rate_pred,
+                    scale=rate_obs_scale
+                   ),
+        obs=rate_obs_loc
+    )
+    return rate_obs
+
+def at_param_w_data(param, ages, years, knot_val, df_data, method='constant'):
+    rate_function = at_param(param, ages, years,
+                             knot_val,                             
+                             method)
+    rate_data_obs = data_model(param, rate_function, df_data)
+    return rate_function
+
+def group_name(sex, location):
+    return f'{sex}_{location}'.replace(' ', '_').lower()
+
+def single_location_model(group, sex, location, ages, years, knot_val_dict, df_data,
+                          include_consistency_constraints=True,
+                         ):
+    group = group_name(sex, location)
+    i = at_param_w_data(f'i_{group}', ages, years,
+                        knot_val_dict['i'],
+                        df_data[df_data.measure == 'i'])
+    r = at_param_w_data(f'r_{group}', ages, years,
+                        knot_val_dict['r'],
+                        df_data[df_data.measure == 'r'])
+    f = at_param_w_data(f'f_{group}', ages, years,
+                        knot_val_dict['f'],
+                        df_data[df_data.measure == 'f'])
+    m = at_param_w_data(f'm_{group}', ages, years,
+                        knot_val_dict['m'],
+                        df_data[df_data.measure == 'm'])
+    
+    p = at_param_w_data(f'p_{group}', ages, years,
+                        knot_val_dict['p'],
+                        df_data[df_data.measure == 'p'], method='linear')
+    
+    if include_consistency_constraints:
+        ode_model(group, p, i, r, f, m, sigma=0.01, ages=ages, years=years)
+    return dict(p=p, i=i, f=f, m=m, r=r)
+
+def ode_model(group, p, i, r, f, m, sigma, ages, years):
+    def dismod_f(t, y, args):
+        S, C = y
+        i, r, f, m = args
+        return (-m*S - i*S + r*C, -m*C + i*S - r*C - f*C)
+
+    def ode_consistency_factor(at):
+        a, t = at
+        dt = 5
+        term = ODETerm(dismod_f)
+        solver = Dopri5()
+        saveat = SaveAt(t0=False, t1=True)
+
+        y0 = (p(a,t), 1-p(a,t))
+        solution = diffeqsolve(term, solver,
+                               t0=t, t1=t+dt,
+                               dt0=.5, y0=y0,
+                               saveat=saveat,
+                               args=[i(a,t), r(a,t), f(a,t), m(a,t)])
+
+        S, C = solution.ys
+        difference = jnp.log(C / (S+C)) - jnp.log(p(a+dt, t+dt))
+        return difference
+
+    # Vectorize the ode_consistency_factor function
+    ode_consistency_factors = jax.vmap(ode_consistency_factor)
+
+    # Create a mesh grid of ages and years
+    age_mesh, year_mesh = jnp.meshgrid(ages[:-1], years[:-1])
+    at_list = jnp.stack([age_mesh.ravel(), year_mesh.ravel()], axis=-1)
+
+    # Compute ODE errors for all age-time combinations at once
+    ode_errors = numpyro.deterministic(f'ode_errors_{group}', ode_consistency_factors(at_list))
+
+    # Add a normal penalty for difference between solution and SC
+    log_pr = dist.Normal(0, sigma).log_prob(ode_errors).sum()
+    numpyro.factor(f'ode_consistency_factor_{group}', log_pr)
+    
+    
+class ConsistentModel:
+    def __init__(self, sexes, ages, years, locations):
+        self.sexes = sexes
+        self.ages = ages
+        self.years = years
+        self.locations = locations
+        
+    def set_data(self, data_dict):
+        df, mu, s2 = {}, {}, {},
+
+        for param in data_dict.keys():
+            for sex in self.sexes:
+                for location in self.locations:
+                    df_param = data_dict[param] # FIXME: this is a hack and the details for what is in data_dict should be thought through and written out!
+                    df[param, sex, location] = df_param
+                    if param == 'pop':
+                        continue
+
+                    mu[param, sex, location], s2[param, sex, location] = \
+                        transform_to_prior(df_param, sex, self.ages, self.years, location)
+
+        for sex in self.sexes:
+            for location in self.locations:
+                mu['r', sex, location] = mu['i', sex, location] * 0 + .5
+                s2['r', sex, location] = mu['i', sex, location] * 0 + .01
+            
+                mu['m', sex, location] = mu['m_all', sex, location] - mu['csmr_with', sex, location]
+                s2['m', sex, location] = s2['m_all', sex, location]
+
+        self.df, self.mu, self.s2 = df, mu, s2, 
+
+    def fit_model(self):
+        # code to come, expect it to take about 2 minutes to run
+        pass
+
+    def get_remission_rate(self):
+        # code to come, will require calling fit_model before it can return something
+        # interactive tests in 2024_10_09a_dismod_at_numpyro_at_refactor_into_vivarium_nih_moud notebook
+        pass
+    

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -14,9 +14,9 @@ import interpax
 from typing import Callable
 
 
-def transform_to_data(param, df_in, sex, ages, years, location):
+def transform_to_data(param, df_in, sex, ages, years):
     """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
-    t = df_in.loc[(location, sex)]
+    t = df_in.loc[sex]
     results = []  # fill with rows of data, then convert to a dataframe
     
     for a in ages:
@@ -35,6 +35,11 @@ def transform_to_data(param, df_in, sex, ages, years, location):
             results.append(row)
 
     return pd.DataFrame(results)
+
+def artifact_to_data_dict(art, sex, ages, years):
+    data_dict = {}
+    for param in art.keys():
+        data_dict[param] = transform_to_data(param, art.load(key), sex, ages, years)
 
 def transform_to_prior(df, sex, ages, years, location):
     """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
@@ -214,42 +219,67 @@ def ode_model(group, p, i, r, f, m, sigma, ages, years):
     
     
 class ConsistentModel:
-    def __init__(self, sexes, ages, years, locations):
-        self.sexes = sexes
+    def __init__(self, sex, ages, years):
+        self.sex = sex
         self.ages = ages
         self.years = years
-        self.locations = locations
-        
-    def set_data(self, data_dict):
-        df, mu, s2 = {}, {}, {},
+    
+    def fit(self, df_data):
+        # expect this to take about 2 minutes to run
+        group = ''
+        ages, years = self.ages, self.years
+        location = ''
+        sex = self.sex
+        def model():
+            knot_val_dict = {}
+            for param in 'pifmr':
+                knot_val_dict[param] = numpyro.sample(
+                    f'{param}_{group}',
+                    dist.TruncatedNormal(loc=jnp.zeros((len(ages), len(years))),
+                                        scale=jnp.ones((len(ages), len(years))),
+                                        low=0.0,
+                                        )
+                )
+            # TODO: consider moving knots of p to midpoints
+            rate_functions = single_location_model(group, sex, location, ages, years, knot_val_dict, df_data,
+                                                include_consistency_constraints=True)
 
-        for param in data_dict.keys():
-            for sex in self.sexes:
-                for location in self.locations:
-                    df_param = data_dict[param] # FIXME: this is a hack and the details for what is in data_dict should be thought through and written out!
-                    df[param, sex, location] = df_param
-                    if param == 'pop':
-                        continue
+        sampler = infer.MCMC(
+            infer.NUTS(model,
+                    init_strategy=numpyro.infer.init_to_value(
+                        values={
+                            f'p_{group}':jnp.ones([len(ages), len(years)])*.05,
+                            f'i_{group}':jnp.ones([len(ages), len(years)])*.05,
+                            f'f_{group}':jnp.ones([len(ages), len(years)])*.05,
+                            f'm_{group}':jnp.ones([len(ages), len(years)])*.05,
+                            f'r_{group}':jnp.ones([len(ages), len(years)])*.05,
+                        }
+                    )
+                ),
+            num_warmup=1_000,
+            num_samples=100,
+            num_chains=1,
+            progress_bar=True,
+        )
 
-                    mu[param, sex, location], s2[param, sex, location] = \
-                        transform_to_prior(df_param, sex, self.ages, self.years, location)
+        sampler.run(jax.random.PRNGKey(0),
+                )
+        self.samples = sampler.get_samples()                                
 
-        for sex in self.sexes:
-            for location in self.locations:
-                mu['r', sex, location] = mu['i', sex, location] * 0 + .5
-                s2['r', sex, location] = mu['i', sex, location] * 0 + .01
-            
-                mu['m', sex, location] = mu['m_all', sex, location] - mu['csmr_with', sex, location]
-                s2['m', sex, location] = s2['m_all', sex, location]
 
-        self.df, self.mu, self.s2 = df, mu, s2, 
+    def get_rate(self, param):
+        # import pdb; pdb.set_trace()
+        assert hasattr(self, 'samples'), 'Must run fit() first'
+        group = ''
 
-    def fit_model(self):
-        # code to come, expect it to take about 2 minutes to run
-        pass
-
-    def get_remission_rate(self):
-        # code to come, will require calling fit_model before it can return something
-        # interactive tests in 2024_10_09a_dismod_at_numpyro_at_refactor_into_vivarium_nih_moud notebook
-        pass
+        rate_table = []
+        for i, a in enumerate(self.ages):
+            for j, t in enumerate(self.years):
+                rate = self.samples[f'{param}_{group}'][:, i, j]
+                
+                row = dict(age_start=a, age_end=a+5, year_start=t, year_end=t+1, sex=self.sex,)
+                for i, r_i in enumerate(rate):
+                    row[f'draw_{i}'] = float(r_i)
+                rate_table.append(row)
+        return pd.DataFrame(rate_table).set_index(['sex', 'age_start', 'age_end', 'year_start', 'year_end'])
     

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -1,62 +1,73 @@
 """NumPyro/JAX implementation of DisMod-AT, refactored from notebook 2024_07_28a_dismod_ipd_ai_refactor.ipynb
 """
-import numpy as np, pandas as pd
+from typing import Callable
 
+import interpax
 import jax
 import jax.numpy as jnp
-
+import numpy as np
 import numpyro
-from numpyro import distributions as dist, infer
-
-from diffrax import diffeqsolve, Dopri5, ODETerm, SaveAt
-import interpax
-
-from typing import Callable
+import pandas as pd
+from diffrax import Dopri5, ODETerm, SaveAt, diffeqsolve
+from numpyro import distributions as dist
+from numpyro import infer
 
 
 def transform_to_data(param, df_in, sex, ages, years):
     """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
     t = df_in.loc[sex]
     results = []  # fill with rows of data, then convert to a dataframe
-    
+
     for a in ages:
         for y in years:
-            row = {'age_start': a, 'age_end': a, 'year_start': y, 'year_end':y, 'sex':sex,
-                   'measure': param, 
-                  }
-            tt = t.query('age_start <= @a and @a < age_end and year_start <= @y and @y < year_end')
+            row = {
+                "age_start": a,
+                "age_end": a,
+                "year_start": y,
+                "year_end": y,
+                "sex": sex,
+                "measure": param,
+            }
+            tt = t.query(
+                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
+            )
             assert len(tt) == 1
-            row['mean'] = np.mean(tt.iloc[0])
-            row['standard_error'] = (np.std(tt.iloc[0])
-                                     + .00000001 # add a little bit to the s2 for everything, just to avoid zeros
-                                    )
+            row["mean"] = np.mean(tt.iloc[0])
+            row["standard_error"] = (
+                np.std(tt.iloc[0])
+                + 0.00000001  # add a little bit to the s2 for everything, just to avoid zeros
+            )
 
-            
             results.append(row)
 
     return pd.DataFrame(results)
+
 
 def artifact_to_data_dict(art, sex, ages, years):
     data_dict = {}
     for param in art.keys():
         data_dict[param] = transform_to_data(param, art.load(key), sex, ages, years)
 
+
 def transform_to_prior(df, sex, ages, years, location):
     """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
     t = df.loc[(location, sex)]
     mu = pd.DataFrame(index=ages, columns=years, dtype=float)
     s2 = pd.DataFrame(index=ages, columns=years, dtype=float)
-    
+
     for a in ages:
         for y in years:
-            tt = t.query('age_start <= @a and @a < age_end and year_start <= @y and @y < year_end')
+            tt = t.query(
+                "age_start <= @a and @a < age_end and year_start <= @y and @y < year_end"
+            )
             assert len(tt) == 1
-            mu.loc[a,y] = np.mean(tt.iloc[0])
-            s2.loc[a,y] = np.var(tt.iloc[0])
-    
+            mu.loc[a, y] = np.mean(tt.iloc[0])
+            s2.loc[a, y] = np.var(tt.iloc[0])
+
     return mu, s2
 
-def at_param(name: str, ages, years, knot_val, method='constant') -> Callable:
+
+def at_param(name: str, ages, years, knot_val, method="constant") -> Callable:
     """Create an age- and time-specific rate function for a DisMod model.
 
     This function generates a 2d-interpolated rate function
@@ -79,7 +90,7 @@ def at_param(name: str, ages, years, knot_val, method='constant') -> Callable:
     function
         A function `f(a, t)` that takes array-like values age `a`
         and time `t` as inputs and returns the interpolated rate value
-        specific to the given age and time. 
+        specific to the given age and time.
 
     Notes
     -----
@@ -88,103 +99,121 @@ def at_param(name: str, ages, years, knot_val, method='constant') -> Callable:
 
     """
 
-    if method=='constant':
+    if method == "constant":
+
         def f(a: jnp.ndarray, t: jnp.ndarray) -> jnp.ndarray:
-            method = 'scan'  # 'scan_unrolled' can be more performant on GPU at the
-                             # expense of additional compile time
-            a_index = jnp.searchsorted(jnp.asarray(ages[1:]),  # Start from ages[1] 
-                                       # so that ages less than ages[1] map to 
-                                       # index 0
-                                       jnp.asarray(a), method=method, side='right')
-            t_index = jnp.searchsorted(jnp.asarray(years[1:]),  # Start from years[1] 
-                                       # so that years less than years[1] map to 
-                                       # index 0
-                                       jnp.asarray(t), method=method, side='right')
+            method = "scan"  # 'scan_unrolled' can be more performant on GPU at the
+            # expense of additional compile time
+            a_index = jnp.searchsorted(
+                jnp.asarray(ages[1:]),  # Start from ages[1]
+                # so that ages less than ages[1] map to
+                # index 0
+                jnp.asarray(a),
+                method=method,
+                side="right",
+            )
+            t_index = jnp.searchsorted(
+                jnp.asarray(years[1:]),  # Start from years[1]
+                # so that years less than years[1] map to
+                # index 0
+                jnp.asarray(t),
+                method=method,
+                side="right",
+            )
             return knot_val[a_index, t_index]
-    elif method == 'linear':
-        f = interpax.Interpolator2D(ages, years, knot_val, method='linear', extrap=True)
+
+    elif method == "linear":
+        f = interpax.Interpolator2D(ages, years, knot_val, method="linear", extrap=True)
     else:
         assert 0, f'Method "{method}" unrecognized, should be "constant" or "linear"'
     return f
 
-def data_model(name, f, df_data): # FIXME: expose beta so it can be common across locations
+
+def data_model(name, f, df_data):  # FIXME: expose beta so it can be common across locations
     if len(df_data) == 0:
         return
-    
-    ages = jnp.array(.5 * (df_data.age_start + df_data.age_end))
-    years = jnp.array(.5 * (df_data.year_start + df_data.year_end))
-    rate_obs_loc = jnp.array(df_data['mean'])
-    rate_obs_scale = jnp.array(df_data['standard_error'])
+
+    ages = jnp.array(0.5 * (df_data.age_start + df_data.age_end))
+    years = jnp.array(0.5 * (df_data.year_start + df_data.year_end))
+    rate_obs_loc = jnp.array(df_data["mean"])
+    rate_obs_scale = jnp.array(df_data["standard_error"])
 
     # refactor the following to use jax.vmap and to include population weights
     rate_pred = jnp.zeros(len(df_data))
     n_points = 5
-    for alpha in np.linspace(0,1,n_points): 
-        ages = jnp.array(alpha*df_data.age_start + (1-alpha)*df_data.age_end)
+    for alpha in np.linspace(0, 1, n_points):
+        ages = jnp.array(alpha * df_data.age_start + (1 - alpha) * df_data.age_end)
         rate_pred += f(ages, years)
     rate_pred /= n_points
-    
-    if len(df_data.filter(like='x_').columns) != 0:
+
+    if len(df_data.filter(like="x_").columns) != 0:
         # include fixed effects
-        X = jnp.array(df_data.filter(like='x_').fillna(0))
+        X = jnp.array(df_data.filter(like="x_").fillna(0))
         beta = numpyro.sample(
-            f'{name}_beta',
-            dist.Normal(loc=jnp.zeros(len(X[0])),
-                        scale=1.0
-                   ),
+            f"{name}_beta",
+            dist.Normal(loc=jnp.zeros(len(X[0])), scale=1.0),
         )
         rate_pred = jnp.exp(jnp.dot(X, beta)) * rate_pred
-    
+
     rate_obs = numpyro.sample(
-        f'{name}_obs',
-        dist.Normal(loc=rate_pred,
-                    scale=rate_obs_scale
-                   ),
-        obs=rate_obs_loc
+        f"{name}_obs", dist.Normal(loc=rate_pred, scale=rate_obs_scale), obs=rate_obs_loc
     )
     return rate_obs
 
-def at_param_w_data(param, ages, years, knot_val, df_data, method='constant'):
-    rate_function = at_param(param, ages, years,
-                             knot_val,                             
-                             method)
+
+def at_param_w_data(param, ages, years, knot_val, df_data, method="constant"):
+    rate_function = at_param(param, ages, years, knot_val, method)
     rate_data_obs = data_model(param, rate_function, df_data)
     return rate_function
 
-def group_name(sex, location):
-    return f'{sex}_{location}'.replace(' ', '_').lower()
 
-def single_location_model(group, sex, location, ages, years, knot_val_dict, df_data,
-                          include_consistency_constraints=True,
-                         ):
+def group_name(sex, location):
+    return f"{sex}_{location}".replace(" ", "_").lower()
+
+
+def single_location_model(
+    group,
+    sex,
+    location,
+    ages,
+    years,
+    knot_val_dict,
+    df_data,
+    include_consistency_constraints=True,
+):
     group = group_name(sex, location)
-    i = at_param_w_data(f'i_{group}', ages, years,
-                        knot_val_dict['i'],
-                        df_data[df_data.measure == 'i'])
-    r = at_param_w_data(f'r_{group}', ages, years,
-                        knot_val_dict['r'],
-                        df_data[df_data.measure == 'r'])
-    f = at_param_w_data(f'f_{group}', ages, years,
-                        knot_val_dict['f'],
-                        df_data[df_data.measure == 'f'])
-    m = at_param_w_data(f'm_{group}', ages, years,
-                        knot_val_dict['m'],
-                        df_data[df_data.measure == 'm'])
-    
-    p = at_param_w_data(f'p_{group}', ages, years,
-                        knot_val_dict['p'],
-                        df_data[df_data.measure == 'p'], method='constant')
-    
+    i = at_param_w_data(
+        f"i_{group}", ages, years, knot_val_dict["i"], df_data[df_data.measure == "i"]
+    )
+    r = at_param_w_data(
+        f"r_{group}", ages, years, knot_val_dict["r"], df_data[df_data.measure == "r"]
+    )
+    f = at_param_w_data(
+        f"f_{group}", ages, years, knot_val_dict["f"], df_data[df_data.measure == "f"]
+    )
+    m = at_param_w_data(
+        f"m_{group}", ages, years, knot_val_dict["m"], df_data[df_data.measure == "m"]
+    )
+
+    p = at_param_w_data(
+        f"p_{group}",
+        ages,
+        years,
+        knot_val_dict["p"],
+        df_data[df_data.measure == "p"],
+        method="constant",
+    )
+
     if include_consistency_constraints:
         ode_model(group, p, i, r, f, m, sigma=0.01, ages=ages, years=years)
     return dict(p=p, i=i, f=f, m=m, r=r)
+
 
 def ode_model(group, p, i, r, f, m, sigma, ages, years):
     def dismod_f(t, y, args):
         S, C = y
         i, r, f, m = args
-        return (-m*S - i*S + r*C,
-                -m*C + i*S - r*C - f*C)
+        return (-m * S - i * S + r * C, -m * C + i * S - r * C - f * C)
 
     def ode_consistency_factor(at):
         a, t = at
@@ -193,15 +222,20 @@ def ode_model(group, p, i, r, f, m, sigma, ages, years):
         solver = Dopri5()
         saveat = SaveAt(t0=False, t1=True)
 
-        y0 = (1-p(a,t), p(a,t))
-        solution = diffeqsolve(term, solver,
-                               t0=t, t1=t+dt,
-                               dt0=.5, y0=y0,
-                               saveat=saveat,
-                               args=[i(a,t), r(a,t), f(a,t), m(a,t)])
+        y0 = (1 - p(a, t), p(a, t))
+        solution = diffeqsolve(
+            term,
+            solver,
+            t0=t,
+            t1=t + dt,
+            dt0=0.5,
+            y0=y0,
+            saveat=saveat,
+            args=[i(a, t), r(a, t), f(a, t), m(a, t)],
+        )
 
         S, C = solution.ys
-        difference = jnp.log(C / (S+C)) - jnp.log(p(a+dt, t+dt))
+        difference = jnp.log(C / (S + C)) - jnp.log(p(a + dt, t + dt))
         return difference
 
     # Vectorize the ode_consistency_factor function
@@ -212,77 +246,97 @@ def ode_model(group, p, i, r, f, m, sigma, ages, years):
     at_list = jnp.stack([age_mesh.ravel(), year_mesh.ravel()], axis=-1)
 
     # Compute ODE errors for all age-time combinations at once
-    ode_errors = numpyro.deterministic(f'ode_errors_{group}', ode_consistency_factors(at_list))
+    ode_errors = numpyro.deterministic(
+        f"ode_errors_{group}", ode_consistency_factors(at_list)
+    )
 
     # Add a normal penalty for difference between solution and SC
     log_pr = dist.Normal(0, sigma).log_prob(ode_errors).sum()
-    numpyro.factor(f'ode_consistency_factor_{group}', log_pr)
-    
-    
+    numpyro.factor(f"ode_consistency_factor_{group}", log_pr)
+
+
 class ConsistentModel:
     def __init__(self, sex, ages, years):
         self.sex = sex
         self.ages = ages
         self.years = years
-    
+
     def fit(self, df_data):
         # expect this to take about 2 minutes to run
-        group = ''
+        group = ""
         ages, years = self.ages, self.years
-        location = ''
+        location = ""
         sex = self.sex
+
         def model():
             knot_val_dict = {}
-            for param in 'pifmr':
+            for param in "pifmr":
                 knot_val_dict[param] = numpyro.sample(
-                    f'{param}_{group}',
-                    dist.TruncatedNormal(loc=jnp.zeros((len(ages), len(years))),
-                                        scale=jnp.ones((len(ages), len(years))),
-                                        low=0.0,
-                                        )
+                    f"{param}_{group}",
+                    dist.TruncatedNormal(
+                        loc=jnp.zeros((len(ages), len(years))),
+                        scale=jnp.ones((len(ages), len(years))),
+                        low=0.0,
+                    ),
                 )
             # TODO: consider moving knots of p to midpoints
-            rate_functions = single_location_model(group, sex, location, ages, years, knot_val_dict, df_data,
-                                                include_consistency_constraints=True)
+            rate_functions = single_location_model(
+                group,
+                sex,
+                location,
+                ages,
+                years,
+                knot_val_dict,
+                df_data,
+                include_consistency_constraints=True,
+            )
 
         sampler = infer.MCMC(
-            infer.NUTS(model,
-                    init_strategy=numpyro.infer.init_to_value(
-                        values={
-                            f'p_{group}':jnp.ones([len(ages), len(years)])*.05,
-                            f'i_{group}':jnp.ones([len(ages), len(years)])*.05,
-                            f'f_{group}':jnp.ones([len(ages), len(years)])*.05,
-                            f'm_{group}':jnp.ones([len(ages), len(years)])*.05,
-                            f'r_{group}':jnp.ones([len(ages), len(years)])*.05,
-                        }
-                    )
+            infer.NUTS(
+                model,
+                init_strategy=numpyro.infer.init_to_value(
+                    values={
+                        f"p_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"i_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"f_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"m_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                        f"r_{group}": jnp.ones([len(ages), len(years)]) * 0.05,
+                    }
                 ),
+            ),
             num_warmup=1_000,
             num_samples=100,
             num_chains=1,
             progress_bar=True,
         )
 
-        sampler.run(jax.random.PRNGKey(0),
-                )
-        self.samples = sampler.get_samples()                                
-
+        sampler.run(
+            jax.random.PRNGKey(0),
+        )
+        self.samples = sampler.get_samples()
 
     def get_rate(self, param, year):
         # import pdb; pdb.set_trace()
-        assert hasattr(self, 'samples'), 'Must run fit() first'
-        group = ''
+        assert hasattr(self, "samples"), "Must run fit() first"
+        group = ""
 
         rate_table = []
         for i, a in enumerate(self.ages):
             for j, t in enumerate(self.years):
                 if year != t:
                     continue
-                rate = self.samples[f'{param}_{group}'][:, i, j]
-                
-                row = dict(age_start=a, age_end=a+5, year_start=t, year_end=t+1, sex=self.sex,)
+                rate = self.samples[f"{param}_{group}"][:, i, j]
+
+                row = dict(
+                    age_start=a,
+                    age_end=a + 5,
+                    year_start=t,
+                    year_end=t + 1,
+                    sex=self.sex,
+                )
                 for i, r_i in enumerate(rate):
-                    row[f'draw_{i}'] = float(r_i)
+                    row[f"draw_{i}"] = float(r_i)
                 rate_table.append(row)
-        return pd.DataFrame(rate_table).set_index(['sex', 'age_start', 'age_end', 'year_start', 'year_end'])
-    
+        return pd.DataFrame(rate_table).set_index(
+            ["sex", "age_start", "age_end", "year_start", "year_end"]
+        )

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -173,7 +173,7 @@ def single_location_model(group, sex, location, ages, years, knot_val_dict, df_d
     
     p = at_param_w_data(f'p_{group}', ages, years,
                         knot_val_dict['p'],
-                        df_data[df_data.measure == 'p'], method='linear')
+                        df_data[df_data.measure == 'p'], method='constant')
     
     if include_consistency_constraints:
         ode_model(group, p, i, r, f, m, sigma=0.01, ages=ages, years=years)
@@ -267,7 +267,7 @@ class ConsistentModel:
         self.samples = sampler.get_samples()                                
 
 
-    def get_rate(self, param):
+    def get_rate(self, param, year):
         # import pdb; pdb.set_trace()
         assert hasattr(self, 'samples'), 'Must run fit() first'
         group = ''
@@ -275,6 +275,8 @@ class ConsistentModel:
         rate_table = []
         for i, a in enumerate(self.ages):
             for j, t in enumerate(self.years):
+                if year != t:
+                    continue
                 rate = self.samples[f'{param}_{group}'][:, i, j]
                 
                 row = dict(age_start=a, age_end=a+5, year_start=t, year_end=t+1, sex=self.sex,)

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -183,7 +183,8 @@ def ode_model(group, p, i, r, f, m, sigma, ages, years):
     def dismod_f(t, y, args):
         S, C = y
         i, r, f, m = args
-        return (-m*S - i*S + r*C, -m*C + i*S - r*C - f*C)
+        return (-m*S - i*S + r*C,
+                -m*C + i*S - r*C - f*C)
 
     def ode_consistency_factor(at):
         a, t = at
@@ -192,7 +193,7 @@ def ode_model(group, p, i, r, f, m, sigma, ages, years):
         solver = Dopri5()
         saveat = SaveAt(t0=False, t1=True)
 
-        y0 = (p(a,t), 1-p(a,t))
+        y0 = (1-p(a,t), p(a,t))
         solution = diffeqsolve(term, solver,
                                t0=t, t1=t+dt,
                                dt0=.5, y0=y0,

--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -305,7 +305,7 @@ class ConsistentModel:
                 ),
             ),
             num_warmup=1_000,
-            num_samples=100,
+            num_samples=1_000,
             num_chains=1,
             progress_bar=True,
         )

--- a/src/vivarium_nih_moud/data/loader.py
+++ b/src/vivarium_nih_moud/data/loader.py
@@ -173,6 +173,19 @@ def find_consistent_remission_rate(
         excess_mortality = get_data(data_keys.OUD.EMR, location)
 
         # TODO: use dismod to get remission rate
+        # dm = dismod_at.ConsistentModel()
+        # dm.set_data(
+        #     {
+        #         "i": incidence_rate,
+        #         "p": prevalence,
+        #         "f": excess_mortality,
+        #     }
+        # )
+        # dm.fit_model()
+        # remission_rate = dm.get_remission_rate()
+        # how should I update the incidence, prevalence, and excess_mortality to be consistent with the remission rate?
+        # incidence_rate = dm.get_incidence() # but how would I save it?
+
         remission_rate = incidence_rate / prevalence
         return remission_rate
     else:

--- a/src/vivarium_nih_moud/data/loader.py
+++ b/src/vivarium_nih_moud/data/loader.py
@@ -55,7 +55,6 @@ def get_data(
         data_keys.POPULATION.ACMR: load_standard_data,
         data_keys.OUD.PREVALENCE: load_standard_data,
         data_keys.OUD.INCIDENCE_RATE: load_standard_data,
-        data_keys.OUD.REMISSION_RATE: find_consistent_remission_rate,
         data_keys.OUD.CSMR: load_standard_data,
         data_keys.OUD.EMR: load_standard_data,
         data_keys.OUD.DISABILITY_WEIGHT: load_standard_data,
@@ -164,33 +163,6 @@ def _load_em_from_meid(location, meid, measure):
 
 
 # project-specific data functions here
-def find_consistent_remission_rate(
-    key: str, location: str, years: Optional[Union[int, str, List[int]]] = None
-) -> pd.DataFrame:
-    if key == data_keys.OUD.REMISSION_RATE:
-        incidence_rate = get_data(data_keys.OUD.INCIDENCE_RATE, location)
-        prevalence = get_data(data_keys.OUD.PREVALENCE, location)
-        excess_mortality = get_data(data_keys.OUD.EMR, location)
-
-        # TODO: use dismod to get remission rate
-        # dm = dismod_at.ConsistentModel()
-        # dm.set_data(
-        #     {
-        #         "i": incidence_rate,
-        #         "p": prevalence,
-        #         "f": excess_mortality,
-        #     }
-        # )
-        # dm.fit_model()
-        # remission_rate = dm.get_remission_rate()
-        # how should I update the incidence, prevalence, and excess_mortality to be consistent with the remission rate?
-        # incidence_rate = dm.get_incidence() # but how would I save it?
-
-        remission_rate = incidence_rate / prevalence
-        return remission_rate
-    else:
-        raise ValueError(f"Unrecognized key {key}")
-
 
 def get_entity(key: Union[str, EntityKey]):
     # Map of entity types to their gbd mappings.

--- a/src/vivarium_nih_moud/data/loader.py
+++ b/src/vivarium_nih_moud/data/loader.py
@@ -164,6 +164,7 @@ def _load_em_from_meid(location, meid, measure):
 
 # project-specific data functions here
 
+
 def get_entity(key: Union[str, EntityKey]):
     # Map of entity types to their gbd mappings.
     type_map = {

--- a/src/vivarium_nih_moud/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_nih_moud/model_specifications/branches/scenarios.yaml
@@ -1,5 +1,5 @@
-input_draw_count: 10
-random_seed_count: 5
+input_draw_count: 20
+random_seed_count: 10
 
 branches:
 # TODO change to name of intervention

--- a/src/vivarium_nih_moud/model_specifications/model_spec.yaml
+++ b/src/vivarium_nih_moud/model_specifications/model_spec.yaml
@@ -4,9 +4,9 @@ components:
             - BasePopulation()
             - Mortality()
         disease:
-            - SIS('opioid_use_disorders')
+            - SIS('oud_consistent')
         results:
-            - DiseaseObserver('opioid_use_disorders')
+            - DiseaseObserver('oud_consistent')
             - ResultsStratifier()
             - DisabilityObserver()
             - MortalityObserver()

--- a/src/vivarium_nih_moud/model_specifications/model_spec.yaml
+++ b/src/vivarium_nih_moud/model_specifications/model_spec.yaml
@@ -6,17 +6,14 @@ components:
         disease:
             - SIS('oud_consistent')
         results:
-            - DiseaseObserver('oud_consistent')
             - ResultsStratifier()
             - DisabilityObserver()
+            - DiseaseObserver('oud_consistent')
             - MortalityObserver()
-
-    # Causes an error if left empty. Uncomment when you have components. 
-    # vivarium_nih_moud.components:
 
 configuration:
     input_data:
-        input_draw_number: 0
+        input_draw_number: 69
         artifact_path: /mnt/team/simulation_science/pub/training/abie/artifacts/washington.hdf
     interpolation:
         order: 0
@@ -24,19 +21,20 @@ configuration:
     randomness:
         map_size: 1_000_000
         key_columns: ['entrance_time', 'age']
-        random_seed: 0
+        random_seed: 4344
+        additional_seed: 169
     time:
         start:
             year: 2019
             month: 1
             day: 1
         end:
-            year: 2019
-            month: 2
+            year: 2040
+            month: 1
             day: 1
         step_size: 7 # Days
     population:
-        population_size: 100
+        population_size: 100_000
         initialization_age_min: 0
         initialization_age_max: 100
         untracking_age: 100
@@ -52,5 +50,3 @@ configuration:
         # mortality:
         #     include:
         #     exclude:
-    opioid_use_disorders:
-        remission_rate: 2.0

--- a/src/vivarium_nih_moud/tools/make_artifacts.py
+++ b/src/vivarium_nih_moud/tools/make_artifacts.py
@@ -235,6 +235,8 @@ def build_single_location_artifact(
             logger.info(f"   - Loading and writing {key} data")
             builder.load_and_write_data(artifact, key, location, years, key in replace_keys)
 
+    builder.generate_consistent_moud_rates(artifact, location, years)
+
     logger.info(f"**Done building -- {location}**")
 
 


### PR DESCRIPTION
## Title: Use a custom implementation of the DisMod-AT approach to get remission, since it is not available from get_draws
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> feature
- *JIRA issue*: none
- *Research reference*: <!--Link to research documentation for code -->none

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This refactors a bunch of statistical computation code from my notebooks into a .py file and eventually will use it.  

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
--> I'm not sure how to store multiple keys in the artifact which I think I should do, since the code here will find different draws from incidence, prevalence, etc that are consistent with the draws of remission it generates.

