### PR TITLE
Fix formatting and relative import for data utilities

### DIFF
--- a/src/vivarium_nih_moud/data/dismod_at.py
+++ b/src/vivarium_nih_moud/data/dismod_at.py
@@ -12,7 +12,8 @@ from diffrax import Dopri5, ODETerm, SaveAt, diffeqsolve
 from numpyro import distributions as dist
 from numpyro import infer
 
-import utils
+from . import utils
+
 
 def transform_to_data(param, df_in, sex, ages, years):
     """Convert artifact data to a format suitable for DisMod-AT-NumPyro."""
@@ -417,10 +418,10 @@ def generate_consistent_moud_rates(art, location: str, years):
                     ages,
                     [2021],
                 ),
-                transform_to_data("ti", utils.generate_constant_data(0.0), sex, ages, [2021]), 
-                transform_to_data("ts", utils.generate_constant_data(0.0), sex, ages, [2021]), 
-                # transform_to_data("tf", utils.generate_constant_data(1.0), sex, ages, [2021]), 
-                # transform_to_data("tx", utils.generate_constant_data(0.0), sex, ages, [2021]), 
+                transform_to_data("ti", utils.generate_constant_data(0.0), sex, ages, [2021]),
+                transform_to_data("ts", utils.generate_constant_data(0.0), sex, ages, [2021]),
+                # transform_to_data("tf", utils.generate_constant_data(1.0), sex, ages, [2021]),
+                # transform_to_data("tx", utils.generate_constant_data(0.0), sex, ages, [2021]),
             ]
         )
         return df_data

--- a/src/vivarium_nih_moud/data/utils.py
+++ b/src/vivarium_nih_moud/data/utils.py
@@ -1,21 +1,27 @@
-import numpy as np, pandas as pd
+import numpy as np
+import pandas as pd
+
 
 def generate_constant_data(data_value):
     ages = np.linspace(0, 100, 11, endpoint=True)
     years = [2021]
-    sexes = ['Male', 'Female']
+    sexes = ["Male", "Female"]
     data = []
     for age in ages:
         for year in years:
             for sex in sexes:
-                data.append({
-                    'age_start': age,
-                    'age_end': age+10,
-                    'year_start': year,
-                    'year_end': year+1,
-                    'sex': sex,
-                })
+                data.append(
+                    {
+                        "age_start": age,
+                        "age_end": age + 10,
+                        "year_start": year,
+                        "year_end": year + 1,
+                        "sex": sex,
+                    }
+                )
                 for i in range(1_000):
-                    data[-1][f'draw_{i}'] = np.clip(data_value+np.random.uniform(0,.1), 0, 1)
+                    data[-1][f"draw_{i}"] = np.clip(
+                        data_value + np.random.uniform(0, 0.1), 0, 1
+                    )
     data = pd.DataFrame(data)
-    return data.set_index(['sex', 'age_start', 'age_end', 'year_start', 'year_end'])
+    return data.set_index(["sex", "age_start", "age_end", "year_start", "year_end"])


### PR DESCRIPTION
## Summary
- format the data utilities and DisMod-AT helper modules with isort/black so style checks pass
- switch the DisMod-AT module to use a relative import for its utilities to ensure packaging works in CI

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68eada3bc2888330a3b1ea3115224560